### PR TITLE
prepare v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -240,24 +240,10 @@
         "fn.name": "1.x.x"
       }
     },
-    "path": {
-      "version": "0.12.7",
-      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
-      "requires": {
-        "process": "^0.11.1",
-        "util": "^0.10.3"
-      }
-    },
     "prism-media": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.2.9.tgz",
       "integrity": "sha512-UHCYuqHipbTR1ZsXr5eg4JUmHER8Ss4YEb9Azn+9zzJ7/jlTtD1h0lc4g6tNx3eMlB8Mp6bfll0LPMAV4R6r3Q=="
-    },
-    "process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -319,14 +305,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
-    },
-    "util": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-      "requires": {
-        "inherits": "2.0.3"
-      }
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,9 +36,10 @@
       "dev": true
     },
     "@types/node": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.1.tgz",
-      "integrity": "sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA=="
+      "version": "15.12.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.1.tgz",
+      "integrity": "sha512-zyxJM8I1c9q5sRMtVF+zdd13Jt6RU4r4qfhTd7lQubyThvLfx6yYekWSQjGCGV2Tkecgxnlpl/DNlb6Hg+dmEw==",
+      "dev": true
     },
     "abort-controller": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -306,6 +306,12 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
+    "typescript": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
+      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+      "dev": true
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -172,11 +172,6 @@
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
-    "graceful-fs": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
-    },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "author": "EliteOneTube",
   "license": "MIT",
   "dependencies": {
-    "@types/node": "^15.6.1",
     "death": "^1.1.0",
     "discord.js": "^12.5.3",
     "dotenv": "^10.0.0",
@@ -18,6 +17,7 @@
     "winston": "^3.3.3"
   },
   "devDependencies": {
-    "@types/death": "^1.1.1"
+    "@types/death": "^1.1.1",
+    "@types/node": "^15.12.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "death": "^1.1.0",
     "discord.js": "^12.5.3",
     "dotenv": "^10.0.0",
-    "graceful-fs": "^4.2.6",
     "path": "^0.12.7",
     "winston": "^3.3.3"
   },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@types/death": "^1.1.1",
-    "@types/node": "^15.12.1"
+    "@types/node": "^15.12.1",
+    "typescript": "^4.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "death": "^1.1.0",
     "discord.js": "^12.5.3",
     "dotenv": "^10.0.0",
-    "path": "^0.12.7",
     "winston": "^3.3.3"
   },
   "devDependencies": {

--- a/src/lib/Bot.ts
+++ b/src/lib/Bot.ts
@@ -15,7 +15,7 @@ export default class Bot {
 
     public start(): void {
         this.client.on('ready', this.ClientReady.bind(this));
-        this.client.on('message', this.commands.handleMessage);
+        this.client.on('message', message => this.commands.handleMessage(message));
         this.commands.init();
     }
 

--- a/src/lib/Commands.ts
+++ b/src/lib/Commands.ts
@@ -221,21 +221,22 @@ export default class Commands {
             }
         } else if (command === 'rename') {
             if (args.length < 2) {
-                return message.reply(`Correct Usage: ${prefix}rename !help help.\nor: "not found" file not found`);
+                return message.reply(`Correct Usage: ${prefix}rename !help help.\nor: ${prefix}rename "not found" file not found`);
             }
             try {
                 const [devCurrent, devRename] = commandParser(message.content);
-                if (['prefix', 'roleID'].includes(devCurrent))
-                    return message.reply(`Can not rename base value ${devCurrent}.`);
-                if (['prefix', 'roleID'].includes(devRename))
-                    return message.reply(`Can not rename to base value ${devRename}.`);
+                if (["prefix", "roleID"].includes(devCurrent))
+                    return message.reply(`Can not rename base value ${'`' + devCurrent + '`'}.`)
+                if (["prefix", "roleID"].includes(devRename))
+                    return message.reply(`Can not rename to base value ${'`' + devRename + '`'}.`)
                 if (options.getOption(devCurrent)[1] === undefined)
                     return message.reply(`Can not rename ${'`' + devCurrent + '`'} it doesn't exist.`);
                 if (options.getOption(devRename)[1] !== undefined)
-                    return message.reply(`Can not rename to ${'`' + devRename + '`'} it already exists.`);
+                    return message.reply(`Can not rename to ${'`' + devRename + '`'} as it already exists.`);
 
-                options.rePointAliases(devCurrent, devRename);
-                delete Object.assign(options, { [devRename]: options[devCurrent] })[devCurrent];
+                options.renameCommand(devCurrent, devRename)
+
+                return message.channel.send(`Renamed ${'`' + devCurrent + '`'} => ${'`' + devRename + '`'}`);
             } catch (err) {
                 return message.reply(err);
             }

--- a/src/lib/Commands.ts
+++ b/src/lib/Commands.ts
@@ -20,13 +20,20 @@ function commandParser(message: string): [string, string] {
     return [splitMessage[1], splitMessage.slice(2).join(' ')];
 }
 
-export default class Commands {
-    private recentlySent: { reply: { [id: string]: number }; command: { [cmd: string]: number } };
+interface RecentlySent {
+    reply: { [id: string]: number };
+    command: { [cmd: string]: number };
+}
 
-    private recentlySentTimeouts: {
-        reply: { [id: string]: NodeJS.Timeout };
-        command: { [cmd: string]: NodeJS.Timeout };
-    };
+interface RecentlySentTimeouts {
+    reply: { [id: string]: NodeJS.Timeout };
+    command: { [cmd: string]: NodeJS.Timeout };
+}
+
+export default class Commands {
+    private recentlySent: RecentlySent;
+
+    private recentlySentTimeouts: RecentlySentTimeouts;
 
     init(): void {
         this.recentlySent = { reply: {}, command: {} };
@@ -221,20 +228,22 @@ export default class Commands {
             }
         } else if (command === 'rename') {
             if (args.length < 2) {
-                return message.reply(`Correct Usage: ${prefix}rename !help help.\nor: ${prefix}rename "not found" file not found`);
+                return message.reply(
+                    `Correct Usage: ${prefix}rename !help help.\nor: ${prefix}rename "not found" file not found`
+                );
             }
             try {
                 const [devCurrent, devRename] = commandParser(message.content);
-                if (["prefix", "roleID"].includes(devCurrent))
-                    return message.reply(`Can not rename base value ${'`' + devCurrent + '`'}.`)
-                if (["prefix", "roleID"].includes(devRename))
-                    return message.reply(`Can not rename to base value ${'`' + devRename + '`'}.`)
+                if (['prefix', 'roleID'].includes(devCurrent))
+                    return message.reply(`Can not rename base value ${'`' + devCurrent + '`'}.`);
+                if (['prefix', 'roleID'].includes(devRename))
+                    return message.reply(`Can not rename to base value ${'`' + devRename + '`'}.`);
                 if (options.getOption(devCurrent)[1] === undefined)
                     return message.reply(`Can not rename ${'`' + devCurrent + '`'} it doesn't exist.`);
                 if (options.getOption(devRename)[1] !== undefined)
                     return message.reply(`Can not rename to ${'`' + devRename + '`'} as it already exists.`);
 
-                options.renameCommand(devCurrent, devRename)
+                options.renameCommand(devCurrent, devRename);
 
                 return message.channel.send(`Renamed ${'`' + devCurrent + '`'} => ${'`' + devRename + '`'}`);
             } catch (err) {

--- a/src/lib/Commands.ts
+++ b/src/lib/Commands.ts
@@ -95,9 +95,7 @@ export default class Commands {
                 delete autoresponses.prefix;
                 delete autoresponses.roleID;
 
-                return message.reply(this.checkSpam(command, message.author.id) ||
-                    `Here's a list of available auto-response keywords:\n- ${Object.keys(autoresponses).join('\n- ')}`
-                );
+                return message.reply(this.checkSpam(command, message.author.id) || options.getList());
             }
 
             return;
@@ -176,9 +174,7 @@ export default class Commands {
             delete autoresponses.prefix;
             delete autoresponses.roleID;
 
-            return message.reply(
-                `Here's a list of available auto-response keywords:\n- ${Object.keys(autoresponses).join('\n- ')}`
-            );
+            return message.reply(options.getList());
         } else if (command === 'alias') {
             if (args.length < 2) {
                 return message.reply(`Correct Usage: ${prefix}alias !help help.\nor: "not found" file not found`);
@@ -188,7 +184,7 @@ export default class Commands {
                 if (["prefix", "roleID"].includes(devAlias)) return message.reply(`Can not alias base value ${devAlias} as a command.`)
                 if (["prefix", "roleID"].includes(devExistingCMD)) return message.reply(`Can not alias base value ${devExistingCMD} as a target.`)
                 if (options.currentOptions[devExistingCMD] === undefined) return message.reply(`Can not target alias for ${'`' + devExistingCMD + '`'} it doesn't exist.`);
-                if (options.currentOptions[devAlias] === undefined) return message.reply(`Can not alias base value ${devAlias} as a command it already exists remove it first.`)
+                if (typeof options.currentOptions[devAlias] === "string") return message.reply(`Can not alias ${devAlias} as it already exists remove it first.`)
 
                 options.handleBaseOptionOrAlias(devAlias, devExistingCMD);
                 return message.channel.send(`Added alias ${devAlias} => ${devExistingCMD}`);

--- a/src/lib/Commands.ts
+++ b/src/lib/Commands.ts
@@ -185,8 +185,10 @@ export default class Commands {
                 message.react('✅');
                 return message.channel.send(
                     `Added auto-reply: ${'`' + devCommand + '`'}, ${
-                        devResponse ? 'with the response: \n> ' + devResponse : 'with the attachment: \n>'
-                    }.`,
+                        devResponse
+                            ? 'with the response:\n> ' + devResponse.replace('\n', '\n> ')
+                            : 'with the attachment:\n'
+                    }`,
                     { files: message.attachments.array() }
                 );
             } catch (err) {
@@ -228,7 +230,9 @@ export default class Commands {
                     message.react('✅');
                     return message.channel.send(
                         `Edited auto-reply: ${'`' + devCommand + '`'}, ${
-                            devResponse ? 'with the response: \n> ' + devResponse : 'with the attachment: \n>'
+                            devResponse
+                                ? 'with the response:\n> ' + devResponse.replace('\n', '\n> ')
+                                : 'with the attachment:\n'
                         }.`,
                         { files: message.attachments.array() }
                     );

--- a/src/lib/Commands.ts
+++ b/src/lib/Commands.ts
@@ -128,7 +128,7 @@ export default class Commands {
                 `Any commands should be run on ${channels.map(channel => `<#${channel}>`).join(', ')}`
             );
         }
-        if (command === 'prefix') {
+        if (command === 'prefix' && isOwner) {
             //check for missing arguments cause people dumb
             if (args.length < 1) {
                 return message.reply(`Correct Usage: ${prefix}prefix newPrefix.`);
@@ -136,6 +136,13 @@ export default class Commands {
             let newPrefix = args.shift();
             options.handleBaseOptionOrAlias('prefix', newPrefix);
             return message.reply(`Changed prefix from ${prefix} to ${newPrefix}`);
+        } else if (command === 'setRole' && isOwner) {
+            if (args.length < 1) {
+                return message.reply(`Correct Usage: ${prefix}setRole roleID.`);
+            }
+            let newRole = args.shift();
+            options.handleBaseOptionOrAlias('roleID', newRole);
+            return message.reply(`Changed roleID to ${newRole}`);
         } else if (command === 'add') {
             if (args.length < 2 && !message.attachments.first()) {
                 return message.reply(`Correct Usage: ${prefix}add command response.`);
@@ -190,13 +197,6 @@ export default class Commands {
             } catch (err) {
                 return message.reply(err);
             }
-        } else if (command === 'setRole') {
-            if (args.length < 1) {
-                return message.reply(`Correct Usage: ${prefix}setRole roleID.`);
-            }
-            let newRole = args.shift();
-            options.handleBaseOptionOrAlias('roleID', newRole);
-            return message.reply(`Changed roleID to ${newRole}`);
         } else if (command === 'list') {
             return message.reply(options.getList());
         } else if (command === 'alias') {

--- a/src/lib/Commands.ts
+++ b/src/lib/Commands.ts
@@ -7,20 +7,26 @@ function commandParser(message: string): [string, string] {
     const splitMessage = message.split(' ').filter(i => i);
     if (splitMessage[1].match(/^["']/)) {
         // to make .test "test\" hehe" usable
-        const endIndex = splitMessage.findIndex(i => i.match(/[^\\]['"]$/)) + 1
-        if (!endIndex) throw "Missing ending quote."
-        const command = splitMessage.slice(1, endIndex).join(' ').replace(/\\(['"])/g, "$1")
+        const endIndex = splitMessage.findIndex(i => i.match(/[^\\]['"]$/)) + 1;
+        if (!endIndex) throw 'Missing ending quote.';
+        const command = splitMessage
+            .slice(1, endIndex)
+            .join(' ')
+            .replace(/\\(['"])/g, '$1');
 
-        return [command.substring(1, command.length - 1), splitMessage.slice(endIndex).join(' ')]
+        return [command.substring(1, command.length - 1), splitMessage.slice(endIndex).join(' ')];
     }
 
-    return [splitMessage[1], splitMessage.slice(2).join(' ')]
+    return [splitMessage[1], splitMessage.slice(2).join(' ')];
 }
 
 export default class Commands {
     private recentlySent: { reply: { [id: string]: number }; command: { [cmd: string]: number } };
 
-    private recentlySentTimeouts: { reply: { [id: string]: NodeJS.Timeout }; command: { [cmd: string]: NodeJS.Timeout } };
+    private recentlySentTimeouts: {
+        reply: { [id: string]: NodeJS.Timeout };
+        command: { [cmd: string]: NodeJS.Timeout };
+    };
 
     init(): void {
         this.recentlySent = { reply: {}, command: {} };
@@ -45,9 +51,7 @@ export default class Commands {
         this.recentlySent.command[command]++;
 
         // Allows the command to be used once every 3 seconds.
-        if (
-            this.recentlySent.command[command] > 1
-        ) {
+        if (this.recentlySent.command[command] > 1) {
             this.resetAfter3Seconds('command', command);
             if (this.recentlySent.command[command] > 3) {
                 return 'bruh';
@@ -60,9 +64,7 @@ export default class Commands {
         this.recentlySent.reply[id]++;
 
         // Allows the command to be used twice every 3 seconds.
-        if (
-            this.recentlySent.reply[id] > 2
-        ) {
+        if (this.recentlySent.reply[id] > 2) {
             this.resetAfter3Seconds('reply', id);
             if (this.recentlySent.reply[id] > 3) {
                 return 'bruh';
@@ -81,7 +83,7 @@ export default class Commands {
     public async handleMessage(message: Message): Promise<Message> {
         //check for auto-response and if found dont continue
         if (channels.includes(message.channel.id)) {
-            const messageOptions = options.getOption(message.content)
+            const messageOptions = options.getOption(message.content);
             if (messageOptions[1]) {
                 const spam = this.checkSpam(messageOptions[0], message.author.id);
                 if (spam === 'bruh') {
@@ -89,7 +91,7 @@ export default class Commands {
                     return;
                 }
 
-                const reply = spam || messageOptions[1]
+                const reply = spam || messageOptions[1];
                 return message.reply(reply as string);
             }
         }
@@ -132,7 +134,7 @@ export default class Commands {
                 return message.reply(`Correct Usage: ${prefix}prefix newPrefix.`);
             }
             let newPrefix = args.shift();
-            options.handleBaseOptionOrAlias("prefix", newPrefix);
+            options.handleBaseOptionOrAlias('prefix', newPrefix);
             return message.reply(`Changed prefix from ${prefix} to ${newPrefix}`);
         } else if (command === 'add') {
             if (args.length < 2 && !message.attachments.first()) {
@@ -140,17 +142,20 @@ export default class Commands {
             }
             try {
                 const [devCommand, devResponse] = commandParser(message.content);
-                if (["prefix", "roleID"].includes(devCommand)) return message.reply(`Can not add base value ${devCommand} as a command.`)
+                if (['prefix', 'roleID'].includes(devCommand))
+                    return message.reply(`Can not add base value ${devCommand} as a command.`);
                 if (options.getOption(devCommand)[1] != undefined) {
                     return message.reply(`Auto-reply for ${'`' + devCommand + '`'} already exists.`);
                 }
                 options.handleOption(devCommand, devResponse, message.attachments.array());
                 return message.channel.send(
-                    `Added auto-reply: ${'`' + devCommand + '`'}, ${devResponse ? ("with the response: \n> " + devResponse) : "with the attachment: \n>"}.`,
+                    `Added auto-reply: ${'`' + devCommand + '`'}, ${
+                        devResponse ? 'with the response: \n> ' + devResponse : 'with the attachment: \n>'
+                    }.`,
                     { files: message.attachments.array() }
                 );
             } catch (err) {
-                return message.reply(err)
+                return message.reply(err);
             }
         } else if (command === 'remove') {
             //check for missing arguments cause people dumb
@@ -158,8 +163,9 @@ export default class Commands {
                 return message.reply(`Correct Usage: ${prefix}remove command.`);
             }
             let delCommand = args.filter(i => i).join(' ');
-            if (["prefix", "roleID"].includes(delCommand)) return message.reply(`Can not remove base value ${delCommand}.`)
-            const isAlias = typeof options.getOption(delCommand, true)[1] === "string" ? "alias" : ""
+            if (['prefix', 'roleID'].includes(delCommand))
+                return message.reply(`Can not remove base value ${delCommand}.`);
+            const isAlias = typeof options.getOption(delCommand, true)[1] === 'string' ? 'alias' : '';
             options.deleteCommand(delCommand);
             return message.reply(`Deleted auto-reply for ${isAlias} ${'`' + delCommand + '`'}`);
         } else if (command === 'edit') {
@@ -169,17 +175,20 @@ export default class Commands {
             }
             try {
                 const [devCommand, devResponse] = commandParser(message.content);
-                if (["prefix", "roleID"].includes(devCommand)) return message.reply(`Can not add base value ${devCommand} as a command.`)
+                if (['prefix', 'roleID'].includes(devCommand))
+                    return message.reply(`Can not add base value ${devCommand} as a command.`);
                 if (options.getOption(devCommand)[1] != undefined) {
                     options.handleOption(devCommand, devResponse, message.attachments.array());
                     return message.channel.send(
-                        `Edited auto-reply: ${'`' + devCommand + '`'}, ${devResponse ? ("with the response: \n> " + devResponse) : "with the attachment: \n>"}.`,
+                        `Edited auto-reply: ${'`' + devCommand + '`'}, ${
+                            devResponse ? 'with the response: \n> ' + devResponse : 'with the attachment: \n>'
+                        }.`,
                         { files: message.attachments.array() }
                     );
                 }
                 return message.reply(`Auto-reply for ${'`' + devCommand + '`'} doesn't exist.`);
             } catch (err) {
-                return message.reply(err)
+                return message.reply(err);
             }
         } else if (command === 'setRole') {
             if (args.length < 1) {
@@ -196,15 +205,19 @@ export default class Commands {
             }
             try {
                 const [devAlias, devExistingCMD] = commandParser(message.content);
-                if (["prefix", "roleID"].includes(devAlias)) return message.reply(`Can not alias base value ${devAlias} as a command.`)
-                if (["prefix", "roleID"].includes(devExistingCMD)) return message.reply(`Can not alias base value ${devExistingCMD} as a target.`)
-                if (options.getOption(devExistingCMD)[1] === undefined) return message.reply(`Can not target alias for ${'`' + devExistingCMD + '`'} it doesn't exist.`);
-                if (options.getOption(devAlias)[1] !== undefined) return message.reply(`Can not alias ${devAlias} as it already exists remove it first.`)
+                if (['prefix', 'roleID'].includes(devAlias))
+                    return message.reply(`Can not alias base value ${devAlias} as a command.`);
+                if (['prefix', 'roleID'].includes(devExistingCMD))
+                    return message.reply(`Can not alias base value ${devExistingCMD} as a target.`);
+                if (options.getOption(devExistingCMD)[1] === undefined)
+                    return message.reply(`Can not target alias for ${'`' + devExistingCMD + '`'} it doesn't exist.`);
+                if (options.getOption(devAlias)[1] !== undefined)
+                    return message.reply(`Can not alias ${devAlias} as it already exists remove it first.`);
 
                 options.handleBaseOptionOrAlias(devAlias, devExistingCMD);
                 return message.channel.send(`Added alias ${devAlias} => ${devExistingCMD}`);
             } catch (err) {
-                return message.reply(err)
+                return message.reply(err);
             }
         } else if (command === 'rename') {
             if (args.length < 2) {
@@ -212,15 +225,19 @@ export default class Commands {
             }
             try {
                 const [devCurrent, devRename] = commandParser(message.content);
-                if (["prefix", "roleID"].includes(devCurrent)) return message.reply(`Can not rename base value ${devCurrent}.`)
-                if (["prefix", "roleID"].includes(devRename)) return message.reply(`Can not rename to base value ${devRename}.`)
-                if (options.getOption(devCurrent)[1] === undefined) return message.reply(`Can not rename ${'`' + devCurrent + '`'} it doesn't exist.`);
-                if (options.getOption(devRename)[1] !== undefined) return message.reply(`Can not rename to ${'`' + devRename + '`'} it already exists.`);
+                if (['prefix', 'roleID'].includes(devCurrent))
+                    return message.reply(`Can not rename base value ${devCurrent}.`);
+                if (['prefix', 'roleID'].includes(devRename))
+                    return message.reply(`Can not rename to base value ${devRename}.`);
+                if (options.getOption(devCurrent)[1] === undefined)
+                    return message.reply(`Can not rename ${'`' + devCurrent + '`'} it doesn't exist.`);
+                if (options.getOption(devRename)[1] !== undefined)
+                    return message.reply(`Can not rename to ${'`' + devRename + '`'} it already exists.`);
 
                 options.rePointAliases(devCurrent, devRename);
                 delete Object.assign(options, { [devRename]: options[devCurrent] })[devCurrent];
             } catch (err) {
-                return message.reply(err)
+                return message.reply(err);
             }
         }
     }

--- a/src/lib/Commands.ts
+++ b/src/lib/Commands.ts
@@ -20,7 +20,7 @@ function commandParser(message: string): [string, string] {
 export default class Commands {
     private recentlySent: { reply: { [id: string]: number }; command: { [cmd: string]: number } };
 
-    private recentlySentTimeouts: { reply: { [id: string]: number }; command: { [cmd: string]: NodeJS.Timeout } };
+    private recentlySentTimeouts: { reply: { [id: string]: NodeJS.Timeout }; command: { [cmd: string]: NodeJS.Timeout } };
 
     init(): void {
         this.recentlySent = { reply: {}, command: {} };

--- a/src/lib/Commands.ts
+++ b/src/lib/Commands.ts
@@ -90,8 +90,7 @@ export default class Commands {
                 }
 
                 const reply = spam || messageOptions[1]
-                // Typescript goes crazy for some reason if I don't make this any
-                return message.reply(reply as any);
+                return message.reply(reply as string);
             }
         }
 

--- a/src/lib/Commands.ts
+++ b/src/lib/Commands.ts
@@ -133,7 +133,7 @@ export default class Commands {
                 return message.reply(`Correct Usage: ${prefix}prefix newPrefix.`);
             }
             let newPrefix = args.shift();
-            options.handleOption(command, newPrefix);
+            options.handleBaseOption("prefix", newPrefix);
             return message.reply(`Changed prefix from ${prefix} to ${newPrefix}`);
         } else if (command === 'add') {
             if (args.length < 2 && !message.attachments.first()) {
@@ -186,7 +186,7 @@ export default class Commands {
                 return message.reply(`Correct Usage: ${prefix}setRole roleID.`);
             }
             let newRole = args.shift();
-            options.handleOption('roleID', newRole);
+            options.handleBaseOption('roleID', newRole);
             return message.reply(`Changed roleID to ${newRole}`);
         } else if (command === 'list') {
             const autoresponses = Object.assign({}, options.currentOptions);

--- a/src/lib/Commands.ts
+++ b/src/lib/Commands.ts
@@ -146,45 +146,50 @@ export default class Commands {
             //check for missing arguments cause people dumb
             if (args.length < 1) {
                 message.react('✋');
-                return message.reply(`Correct Usage: ${prefix}prefix newPrefix.`);
+                return message.reply(`**Correct Usage**: \`${prefix}prefix <newPrefix>\``);
             }
 
             const newPrefix = args.shift();
             options.handleBaseOptionOrAlias('prefix', newPrefix);
             message.react('✅');
-            return message.reply(`Changed prefix from ${prefix} to ${newPrefix}`);
+            return message.reply(`Changed prefix from \`${prefix}\` to \`${newPrefix}\``);
         } else if (command === 'setRole' && isOwner) {
             if (args.length < 1) {
                 message.react('✋');
-                return message.reply(`Correct Usage: ${prefix}setRole roleID.`);
+                return message.reply(`**Correct Usage**: \`${prefix}setRole <roleID>\``);
             }
 
             const newRole = args.shift();
             options.handleBaseOptionOrAlias('roleID', newRole);
             message.react('✅');
-            return message.reply(`Changed roleID to ${newRole}`);
+            return message.reply(`Changed roleID to \`${newRole}\``);
         } else if (command === 'add') {
             if (args.length < 2 && !message.attachments.first()) {
                 message.react('✋');
-                return message.reply(`Correct Usage: ${prefix}add command response.`);
+                return message.reply(
+                    `**Correct Usage**: \`${prefix}add <newKeyword> <response>\`` +
+                        `\n__Example__:\n- ${prefix}add pm2 Short for Process Manager 2` +
+                        `\n- ${prefix}add "manual review" You manually review and then manually accept/decline` +
+                        `\n\n📌Note📌\n\`<response>\` can either be descriptions together with an attachment, or just an attachment (i.e. image, file).`
+                );
             }
 
             try {
                 const [devCommand, devResponse] = commandParser(message.content);
                 if (['prefix', 'roleID'].includes(devCommand)) {
                     message.react('❌');
-                    return message.reply(`Can not add base value ${devCommand} as a command.`);
+                    return message.reply(`Can not add base value \`${devCommand}\` as a command.`);
                 }
 
                 if (options.getOption(devCommand)[1] != undefined) {
                     message.react('❌');
-                    return message.reply(`Auto-reply for ${'`' + devCommand + '`'} already exists.`);
+                    return message.reply(`Auto-reply for \`${devCommand}\` already exists.`);
                 }
 
                 options.handleOption(devCommand, devResponse, message.attachments.array());
                 message.react('✅');
                 return message.channel.send(
-                    `Added auto-reply: ${'`' + devCommand + '`'}, ${
+                    `Added auto-reply: \`${devCommand}\`, ${
                         devResponse
                             ? 'with the response:\n> ' + devResponse.replace('\n', '\n> ')
                             : 'with the attachment:\n'
@@ -199,37 +204,42 @@ export default class Commands {
             //check for missing arguments cause people dumb
             if (args.length < 1) {
                 message.react('✋');
-                return message.reply(`Correct Usage: ${prefix}remove command.`);
+                return message.reply(`**Correct Usage**: \`${prefix}remove <existingKeyword>\``);
             }
 
             const delCommand = args.filter(i => i).join(' ');
             if (['prefix', 'roleID'].includes(delCommand)) {
-                return message.reply(`Can not remove base value ${delCommand}.`);
+                return message.reply(`Can not remove base value \`${delCommand}\``);
             }
 
             const isAlias = typeof options.getOption(delCommand, true)[1] === 'string' ? 'alias' : '';
             options.deleteCommand(delCommand);
             message.react('🚮');
-            return message.reply(`Deleted auto-reply for ${isAlias} ${'`' + delCommand + '`'}`);
+            return message.reply(`Deleted auto-reply for ${isAlias} \`${delCommand}\``);
         } else if (command === 'edit') {
             //check for missing arguments cause people dumb
             if (args.length < 2 && !message.attachments.first()) {
                 message.react('✋');
-                return message.reply(`Correct Usage: ${prefix}edit command newResponse.`);
+                return message.reply(
+                    `**Correct Usage**: \`${prefix}edit <existingKeyword> <newResponse>\`` +
+                        `\n__Example__:\n- ${prefix}edit pm2 Short for Process Manager 2` +
+                        `\n- ${prefix}edit "manual review" You manually review and then manually accept/decline` +
+                        `\n\n📌Note📌\n\`<newResponse>\` can either be descriptions together with an attachment, or just an attachment (i.e. image, file).`
+                );
             }
 
             try {
                 const [devCommand, devResponse] = commandParser(message.content);
                 if (['prefix', 'roleID'].includes(devCommand)) {
                     message.react('❌');
-                    return message.reply(`Can not add base value ${devCommand} as a command.`);
+                    return message.reply(`Can not add base value \`${devCommand}\` as a command.`);
                 }
 
                 if (options.getOption(devCommand)[1] != undefined) {
                     options.handleOption(devCommand, devResponse, message.attachments.array());
                     message.react('✅');
                     return message.channel.send(
-                        `Edited auto-reply: ${'`' + devCommand + '`'}, ${
+                        `Edited auto-reply: \`${devCommand}\`, ${
                             devResponse
                                 ? 'with the response:\n> ' + devResponse.replace('\n', '\n> ')
                                 : 'with the attachment:\n'
@@ -239,7 +249,7 @@ export default class Commands {
                 }
 
                 message.react('❌');
-                return message.reply(`Auto-reply for ${'`' + devCommand + '`'} doesn't exist.`);
+                return message.reply(`Auto-reply for \`${devCommand}\` doesn't exist.`);
             } catch (err) {
                 message.react('❌');
                 return message.reply(err);
@@ -250,33 +260,38 @@ export default class Commands {
         } else if (command === 'alias') {
             if (args.length < 2) {
                 message.react('✋');
-                return message.reply(`Correct Usage: ${prefix}alias !help help.\nor: "not found" file not found`);
+                return message.reply(
+                    `**Correct Usage**: \`${prefix}alias <newAlias> <currentExistingKeyword>\`` +
+                        `\n__Example__:\n- ${prefix}alias !help help\n- "not found" file not found`
+                );
             }
             try {
                 const [devAlias, devExistingCMD] = commandParser(message.content);
                 if (['prefix', 'roleID'].includes(devAlias)) {
                     message.react('❌');
-                    return message.reply(`Can not alias base value ${devAlias} as a command.`);
+                    return message.reply(`Can not alias base value \`${devAlias}\` as a command.`);
                 }
 
                 if (['prefix', 'roleID'].includes(devExistingCMD)) {
                     message.react('❌');
-                    return message.reply(`Can not alias base value ${devExistingCMD} as a target.`);
+                    return message.reply(`Can not alias base value \`${devExistingCMD}\` as a target.`);
                 }
 
                 if (options.getOption(devExistingCMD)[1] === undefined) {
                     message.react('❌');
-                    return message.reply(`Can not target alias for ${'`' + devExistingCMD + '`'} it doesn't exist.`);
+                    return message.reply(`Can not target alias for \`${devExistingCMD}\` it doesn't exist.`);
                 }
 
                 if (options.getOption(devAlias)[1] !== undefined) {
                     message.react('❌');
-                    return message.reply(`Can not alias ${devAlias} as it already exists remove it first.`);
+                    return message.reply(`Can not alias \`${devAlias}\` as it already exists remove it first.`);
                 }
 
                 options.handleBaseOptionOrAlias(devAlias, options.getOption(devExistingCMD)[0]);
                 message.react('✅');
-                return message.channel.send(`Added alias ${devAlias} => ${options.getOption(devExistingCMD)[0]}`);
+                return message.channel.send(
+                    `Added alias \`${devAlias}\` => \`${options.getOption(devExistingCMD)[0]}\``
+                );
             } catch (err) {
                 message.react('❌');
                 return message.reply(err);
@@ -285,7 +300,9 @@ export default class Commands {
             if (args.length < 2) {
                 message.react('✋');
                 return message.reply(
-                    `Correct Usage: ${prefix}rename !help help.\nor: ${prefix}rename "not found" file not found`
+                    `**Correct Usage**: \`${prefix}rename <currentExistingKeyword> <newKeyword>\`` +
+                        `\n__Example__:\n- ${prefix}rename !help help` +
+                        `\n- ${prefix}rename "not found" file not found`
                 );
             }
 
@@ -293,25 +310,25 @@ export default class Commands {
                 const [devCurrent, devRename] = commandParser(message.content);
                 if (['prefix', 'roleID'].includes(devCurrent)) {
                     message.react('❌');
-                    return message.reply(`Can not rename base value ${'`' + devCurrent + '`'}.`);
+                    return message.reply(`Can not rename base value \`${devCurrent}\`.`);
                 }
                 if (['prefix', 'roleID'].includes(devRename)) {
                     message.react('❌');
-                    return message.reply(`Can not rename to base value ${'`' + devRename + '`'}.`);
+                    return message.reply(`Can not rename to base value \`${devRename}\`.`);
                 }
                 if (options.getOption(devCurrent)[1] === undefined) {
                     message.react('❌');
-                    return message.reply(`Can not rename ${'`' + devCurrent + '`'} it doesn't exist.`);
+                    return message.reply(`Can not rename \`${devCurrent}\` it doesn't exist.`);
                 }
                 if (options.getOption(devRename)[1] !== undefined) {
                     message.react('❌');
-                    return message.reply(`Can not rename to ${'`' + devRename + '`'} as it already exists.`);
+                    return message.reply(`Can not rename to \`${devRename}\` as it already exists.`);
                 }
 
                 options.renameCommand(devCurrent, devRename);
 
                 message.react('✅');
-                return message.channel.send(`Renamed ${'`' + devCurrent + '`'} => ${'`' + devRename + '`'}`);
+                return message.channel.send(`Renamed \`${devCurrent}\` => \`${devRename}\``);
             } catch (err) {
                 message.react('❌');
                 return message.reply(err);

--- a/src/lib/Commands.ts
+++ b/src/lib/Commands.ts
@@ -214,8 +214,8 @@ export default class Commands {
                 if (options.getOption(devAlias)[1] !== undefined)
                     return message.reply(`Can not alias ${devAlias} as it already exists remove it first.`);
 
-                options.handleBaseOptionOrAlias(devAlias, devExistingCMD);
-                return message.channel.send(`Added alias ${devAlias} => ${devExistingCMD}`);
+                options.handleBaseOptionOrAlias(devAlias, options.getOption(devExistingCMD)[0]);
+                return message.channel.send(`Added alias ${devAlias} => ${options.getOption(devExistingCMD)[0]}`);
             } catch (err) {
                 return message.reply(err);
             }

--- a/src/lib/Commands.ts
+++ b/src/lib/Commands.ts
@@ -95,7 +95,7 @@ export default class Commands {
                 delete autoresponses.prefix;
                 delete autoresponses.roleID;
 
-                return message.reply(this.checkSpam(message.content, message.author.id) ||
+                return message.reply(this.checkSpam(command, message.author.id) ||
                     `Here's a list of available auto-response keywords:\n- ${Object.keys(autoresponses).join('\n- ')}`
                 );
             }

--- a/src/lib/Commands.ts
+++ b/src/lib/Commands.ts
@@ -72,7 +72,7 @@ export default class Commands {
         //check for auto-response and if found dont continue
         if (channels.includes(message.channel.id)) {
             const messageOptions = options.getOption(message.content)
-            if (messageOptions) {
+            if (messageOptions[1]) {
                 const reply = this.checkSpam(messageOptions[0], message.author.id) || messageOptions[1]
                 // Typescript goes crazy for some reason if I don't make this any
                 return message.reply(reply as any);

--- a/src/lib/Commands.ts
+++ b/src/lib/Commands.ts
@@ -75,7 +75,7 @@ export default class Commands {
             if (messageOptions) {
                 const reply = this.checkSpam(messageOptions[0], message.author.id) || messageOptions[1]
                 // Typescript goes crazy for some reason if I don't make this any
-                return void message.reply(reply as any);
+                return message.reply(reply as any);
             }
         }
 

--- a/src/lib/Commands.ts
+++ b/src/lib/Commands.ts
@@ -18,18 +18,26 @@ function commandParser(message: string): [string, string] {
 }
 
 export default class Commands {
-    private recentlySentReply: { [id: string]: number } = {};
+    private recentlySent: { reply: { [id: string]: number }; command: { [cmd: string]: number } };
 
-    private poller: NodeJS.Timeout;
+    private resetRecentlySentReply: NodeJS.Timeout;
+
+    private resetRecentlySentCommand: NodeJS.Timeout;
 
     init(): void {
-        this.poller = setInterval(() => {
-            this.recentlySentReply = {};
-        }, 3000);
+        this.recentlySent = { reply: {}, command: {} };
     }
 
     stop(): void {
-        this.poller = undefined;
+        this.recentlySent = undefined;
+        this.resetRecentlySentReply = undefined;
+        this.resetRecentlySentCommand = undefined;
+    }
+
+    private resetAfter3Seconds(type: 'reply' | 'command', idOrCommand: string): void {
+        this[`resetRecentlySent${type.charAt(0).toUpperCase() + type.slice(1)}`] = setTimeout(() => {
+            delete this.recentlySent[type][idOrCommand];
+        }, 3000);
     }
 
     //message should be type of Message from discord but that way typescript throws error on line 8
@@ -38,20 +46,30 @@ export default class Commands {
         if (channels.includes(message.channel.id)) {
             const messageOptions = options.getOption(message.content)
             if (messageOptions) {
-                if (this.recentlySentReply === undefined) {
-                    this.recentlySentReply = {}; // not sure why undefined here. should already defined 🤔
-                }
-
-                this.recentlySentReply[message.author.id] = (this.recentlySentReply[message.author.id] || -1) + 1;
+                clearTimeout(this.resetRecentlySentReply);
+                clearTimeout(this.resetRecentlySentCommand);
+                this.recentlySent.command[message.content] = (this.recentlySent.command[message.content] ?? -1) + 1;
 
                 if (
-                    this.recentlySentReply[message.author.id] !== undefined &&
-                    this.recentlySentReply[message.author.id] > 2
+                    this.recentlySent.command[message.content] !== undefined &&
+                    this.recentlySent.command[message.content] > 1
                 ) {
-                    return message.reply(`Bruh stop spamming :prettypepepuke:`);
+                    this.resetAfter3Seconds('command', message.content);
+                    return message.reply(`I have just sent a reply for that ⛔`);
                 }
-                message.reply(messageOptions);
-                return;
+
+                this.recentlySent.reply[message.author.id] = (this.recentlySent.reply[message.author.id] ?? -1) + 1;
+
+                if (
+                    this.recentlySent.reply[message.author.id] !== undefined &&
+                    this.recentlySent.reply[message.author.id] > 2
+                ) {
+                    this.resetAfter3Seconds('reply', message.author.id);
+                    return message.reply(`Bruh stop spamming ⛔`);
+                }
+
+                this.resetAfter3Seconds('reply', message.author.id);
+                return message.reply(options.currentOptions[message.content]);
             }
         }
 
@@ -73,17 +91,26 @@ export default class Commands {
                 delete autoresponses.prefix;
                 delete autoresponses.roleID;
 
-                if (this.recentlySentReply === undefined) {
-                    this.recentlySentReply = {}; // not sure why undefined here. should already defined 🤔
-                }
-
-                this.recentlySentReply[message.author.id] = (this.recentlySentReply[message.author.id] || -1) + 1;
+                clearTimeout(this.resetRecentlySentReply);
+                clearTimeout(this.resetRecentlySentCommand);
+                this.recentlySent.command[command] = (this.recentlySent.command[command] ?? -1) + 1;
 
                 if (
-                    this.recentlySentReply[message.author.id] !== undefined &&
-                    this.recentlySentReply[message.author.id] > 2
+                    this.recentlySent.command[command] !== undefined &&
+                    this.recentlySent.command[command] > 1
                 ) {
-                    return message.reply(`Bruh stop spamming :prettypepepuke:`);
+                    this.resetAfter3Seconds('command', command);
+                    return message.reply(`I have just sent a reply for that ⛔`);
+                }
+
+                this.recentlySent.reply[message.author.id] = (this.recentlySent.reply[message.author.id] ?? -1) + 1;
+
+                if (
+                    this.recentlySent.reply[message.author.id] !== undefined &&
+                    this.recentlySent.reply[message.author.id] > 2
+                ) {
+                    this.resetAfter3Seconds('reply', message.author.id);
+                    return message.reply(`Bruh stop spamming ⛔`);
                 }
 
                 return message.reply(

--- a/src/lib/Commands.ts
+++ b/src/lib/Commands.ts
@@ -1,5 +1,5 @@
 import { options } from '../app';
-import { Message } from 'discord.js';
+import { Message, MessageReaction } from 'discord.js';
 const channels = JSON.parse(process.env.CHANNEL_IDS) as string[];
 
 function commandParser(message: string): [string, string] {
@@ -87,19 +87,21 @@ export default class Commands {
     }
 
     //message should be type of Message from discord but that way typescript throws error on line 8
-    public async handleMessage(message: Message): Promise<Message> {
+    public async handleMessage(message: Message): Promise<Message | MessageReaction> {
         //check for auto-response and if found dont continue
         if (channels.includes(message.channel.id)) {
             const messageOptions = options.getOption(message.content);
             if (messageOptions[1]) {
                 const spam = this.checkSpam(messageOptions[0], message.author.id);
                 if (spam === 'bruh') {
-                    message.react('🤬');
-                    return;
+                    return message.react('🤬');
                 }
 
-                const reply = spam || messageOptions[1];
-                return message.reply(reply as string);
+                if (spam === null) {
+                    message.react('👍');
+                }
+
+                return message.reply((spam || messageOptions[1]) as string);
             }
         }
 
@@ -117,13 +119,16 @@ export default class Commands {
         const isOwner = message.guild.ownerID === message.author.id;
         if (!message.member.roles.cache.find(r => r.id == roleID) && !isOwner) {
             if (command === 'list') {
-                const reply = this.checkSpam(command, message.author.id);
-                if (reply === 'bruh') {
-                    message.react('🤬');
-                    return;
+                const checkSpam = this.checkSpam(command, message.author.id);
+                if (checkSpam === 'bruh') {
+                    return message.react('🤬');
                 }
 
-                return message.reply(reply || options.getList());
+                if (checkSpam === null) {
+                    message.react('👍');
+                }
+
+                return message.reply(checkSpam || options.getList());
             }
 
             return;
@@ -131,123 +136,189 @@ export default class Commands {
 
         //check if its on correct channel
         if (!channels.includes(message.channel.id) && channels.length != 0) {
-            return message.reply(
-                `Any commands should be run on ${channels.map(channel => `<#${channel}>`).join(', ')}`
-            );
+            return message
+                .reply(`Any commands should be run on ${channels.map(channel => `<#${channel}>`).join(', ')}`)
+                .then(message => message.react('❌'));
         }
+
         if (command === 'prefix' && isOwner) {
             //check for missing arguments cause people dumb
             if (args.length < 1) {
-                return message.reply(`Correct Usage: ${prefix}prefix newPrefix.`);
+                return message.reply(`Correct Usage: ${prefix}prefix newPrefix.`).then(message => message.react('✋'));
             }
-            let newPrefix = args.shift();
+
+            const newPrefix = args.shift();
             options.handleBaseOptionOrAlias('prefix', newPrefix);
-            return message.reply(`Changed prefix from ${prefix} to ${newPrefix}`);
+            return message.reply(`Changed prefix from ${prefix} to ${newPrefix}`).then(message => message.react('✅'));
         } else if (command === 'setRole' && isOwner) {
             if (args.length < 1) {
-                return message.reply(`Correct Usage: ${prefix}setRole roleID.`);
+                return message.reply(`Correct Usage: ${prefix}setRole roleID.`).then(message => message.react('✋'));
             }
-            let newRole = args.shift();
+
+            const newRole = args.shift();
             options.handleBaseOptionOrAlias('roleID', newRole);
-            return message.reply(`Changed roleID to ${newRole}`);
+            return message.reply(`Changed roleID to ${newRole}`).then(message => message.react('✅'));
         } else if (command === 'add') {
             if (args.length < 2 && !message.attachments.first()) {
-                return message.reply(`Correct Usage: ${prefix}add command response.`);
+                return message
+                    .reply(`Correct Usage: ${prefix}add command response.`)
+                    .then(message => message.react('✋'));
             }
+
             try {
                 const [devCommand, devResponse] = commandParser(message.content);
-                if (['prefix', 'roleID'].includes(devCommand))
-                    return message.reply(`Can not add base value ${devCommand} as a command.`);
-                if (options.getOption(devCommand)[1] != undefined) {
-                    return message.reply(`Auto-reply for ${'`' + devCommand + '`'} already exists.`);
+                if (['prefix', 'roleID'].includes(devCommand)) {
+                    return message
+                        .reply(`Can not add base value ${devCommand} as a command.`)
+                        .then(message => message.react('❌'));
                 }
+
+                if (options.getOption(devCommand)[1] != undefined) {
+                    return message
+                        .reply(`Auto-reply for ${'`' + devCommand + '`'} already exists.`)
+                        .then(message => message.react('❌'));
+                }
+
                 options.handleOption(devCommand, devResponse, message.attachments.array());
-                return message.channel.send(
-                    `Added auto-reply: ${'`' + devCommand + '`'}, ${
-                        devResponse ? 'with the response: \n> ' + devResponse : 'with the attachment: \n>'
-                    }.`,
-                    { files: message.attachments.array() }
-                );
+                return message.channel
+                    .send(
+                        `Added auto-reply: ${'`' + devCommand + '`'}, ${
+                            devResponse ? 'with the response: \n> ' + devResponse : 'with the attachment: \n>'
+                        }.`,
+                        { files: message.attachments.array() }
+                    )
+                    .then(message => message.react('✅'));
             } catch (err) {
-                return message.reply(err);
+                return message.reply(err).then(message => message.react('❌'));
             }
         } else if (command === 'remove') {
             //check for missing arguments cause people dumb
             if (args.length < 1) {
-                return message.reply(`Correct Usage: ${prefix}remove command.`);
+                return message.reply(`Correct Usage: ${prefix}remove command.`).then(message => message.react('✋'));
             }
-            let delCommand = args.filter(i => i).join(' ');
-            if (['prefix', 'roleID'].includes(delCommand))
+
+            const delCommand = args.filter(i => i).join(' ');
+            if (['prefix', 'roleID'].includes(delCommand)) {
                 return message.reply(`Can not remove base value ${delCommand}.`);
+            }
+
             const isAlias = typeof options.getOption(delCommand, true)[1] === 'string' ? 'alias' : '';
             options.deleteCommand(delCommand);
-            return message.reply(`Deleted auto-reply for ${isAlias} ${'`' + delCommand + '`'}`);
+            return message
+                .reply(`Deleted auto-reply for ${isAlias} ${'`' + delCommand + '`'}`)
+                .then(message => message.react('🚮'));
         } else if (command === 'edit') {
             //check for missing arguments cause people dumb
             if (args.length < 2 && !message.attachments.first()) {
-                return message.reply(`Correct Usage: ${prefix}edit command newResponse.`);
+                return message
+                    .reply(`Correct Usage: ${prefix}edit command newResponse.`)
+                    .then(message => message.react('✋'));
             }
+
             try {
                 const [devCommand, devResponse] = commandParser(message.content);
-                if (['prefix', 'roleID'].includes(devCommand))
-                    return message.reply(`Can not add base value ${devCommand} as a command.`);
+                if (['prefix', 'roleID'].includes(devCommand)) {
+                    return message
+                        .reply(`Can not add base value ${devCommand} as a command.`)
+                        .then(message => message.react('❌'));
+                }
+
                 if (options.getOption(devCommand)[1] != undefined) {
                     options.handleOption(devCommand, devResponse, message.attachments.array());
-                    return message.channel.send(
-                        `Edited auto-reply: ${'`' + devCommand + '`'}, ${
-                            devResponse ? 'with the response: \n> ' + devResponse : 'with the attachment: \n>'
-                        }.`,
-                        { files: message.attachments.array() }
-                    );
+                    return message.channel
+                        .send(
+                            `Edited auto-reply: ${'`' + devCommand + '`'}, ${
+                                devResponse ? 'with the response: \n> ' + devResponse : 'with the attachment: \n>'
+                            }.`,
+                            { files: message.attachments.array() }
+                        )
+                        .then(message => message.react('✅'));
                 }
-                return message.reply(`Auto-reply for ${'`' + devCommand + '`'} doesn't exist.`);
+
+                return message
+                    .reply(`Auto-reply for ${'`' + devCommand + '`'} doesn't exist.`)
+                    .then(message => message.react('❌'));
             } catch (err) {
-                return message.reply(err);
+                return message.reply(err).then(message => message.react('❌'));
             }
         } else if (command === 'list') {
-            return message.reply(options.getList());
+            return message.reply(options.getList()).then(message => message.react('✅'));
         } else if (command === 'alias') {
             if (args.length < 2) {
-                return message.reply(`Correct Usage: ${prefix}alias !help help.\nor: "not found" file not found`);
+                return message
+                    .reply(`Correct Usage: ${prefix}alias !help help.\nor: "not found" file not found`)
+                    .then(message => message.react('✋'));
             }
             try {
                 const [devAlias, devExistingCMD] = commandParser(message.content);
-                if (['prefix', 'roleID'].includes(devAlias))
-                    return message.reply(`Can not alias base value ${devAlias} as a command.`);
-                if (['prefix', 'roleID'].includes(devExistingCMD))
-                    return message.reply(`Can not alias base value ${devExistingCMD} as a target.`);
-                if (options.getOption(devExistingCMD)[1] === undefined)
-                    return message.reply(`Can not target alias for ${'`' + devExistingCMD + '`'} it doesn't exist.`);
-                if (options.getOption(devAlias)[1] !== undefined)
-                    return message.reply(`Can not alias ${devAlias} as it already exists remove it first.`);
+                if (['prefix', 'roleID'].includes(devAlias)) {
+                    return message
+                        .reply(`Can not alias base value ${devAlias} as a command.`)
+                        .then(message => message.react('❌'));
+                }
+
+                if (['prefix', 'roleID'].includes(devExistingCMD)) {
+                    return message
+                        .reply(`Can not alias base value ${devExistingCMD} as a target.`)
+                        .then(message => message.react('❌'));
+                }
+
+                if (options.getOption(devExistingCMD)[1] === undefined) {
+                    return message
+                        .reply(`Can not target alias for ${'`' + devExistingCMD + '`'} it doesn't exist.`)
+                        .then(message => message.react('❌'));
+                }
+
+                if (options.getOption(devAlias)[1] !== undefined) {
+                    return message
+                        .reply(`Can not alias ${devAlias} as it already exists remove it first.`)
+                        .then(message => message.react('❌'));
+                }
 
                 options.handleBaseOptionOrAlias(devAlias, options.getOption(devExistingCMD)[0]);
-                return message.channel.send(`Added alias ${devAlias} => ${options.getOption(devExistingCMD)[0]}`);
+                return message.channel
+                    .send(`Added alias ${devAlias} => ${options.getOption(devExistingCMD)[0]}`)
+                    .then(message => message.react('✅'));
             } catch (err) {
-                return message.reply(err);
+                return message.reply(err).then(message => message.react('❌'));
             }
         } else if (command === 'rename') {
             if (args.length < 2) {
-                return message.reply(
-                    `Correct Usage: ${prefix}rename !help help.\nor: ${prefix}rename "not found" file not found`
-                );
+                return message
+                    .reply(`Correct Usage: ${prefix}rename !help help.\nor: ${prefix}rename "not found" file not found`)
+                    .then(message => message.react('✋'));
             }
+
             try {
                 const [devCurrent, devRename] = commandParser(message.content);
-                if (['prefix', 'roleID'].includes(devCurrent))
-                    return message.reply(`Can not rename base value ${'`' + devCurrent + '`'}.`);
-                if (['prefix', 'roleID'].includes(devRename))
-                    return message.reply(`Can not rename to base value ${'`' + devRename + '`'}.`);
-                if (options.getOption(devCurrent)[1] === undefined)
-                    return message.reply(`Can not rename ${'`' + devCurrent + '`'} it doesn't exist.`);
-                if (options.getOption(devRename)[1] !== undefined)
-                    return message.reply(`Can not rename to ${'`' + devRename + '`'} as it already exists.`);
+                if (['prefix', 'roleID'].includes(devCurrent)) {
+                    return message
+                        .reply(`Can not rename base value ${'`' + devCurrent + '`'}.`)
+                        .then(message => message.react('❌'));
+                }
+                if (['prefix', 'roleID'].includes(devRename)) {
+                    return message
+                        .reply(`Can not rename to base value ${'`' + devRename + '`'}.`)
+                        .then(message => message.react('❌'));
+                }
+                if (options.getOption(devCurrent)[1] === undefined) {
+                    return message
+                        .reply(`Can not rename ${'`' + devCurrent + '`'} it doesn't exist.`)
+                        .then(message => message.react('❌'));
+                }
+                if (options.getOption(devRename)[1] !== undefined) {
+                    return message
+                        .reply(`Can not rename to ${'`' + devRename + '`'} as it already exists.`)
+                        .then(message => message.react('❌'));
+                }
 
                 options.renameCommand(devCurrent, devRename);
 
-                return message.channel.send(`Renamed ${'`' + devCurrent + '`'} => ${'`' + devRename + '`'}`);
+                return message.channel
+                    .send(`Renamed ${'`' + devCurrent + '`'} => ${'`' + devRename + '`'}`)
+                    .then(message => message.react('✅'));
             } catch (err) {
-                return message.reply(err);
+                return message.reply(err).then(message => message.react('❌'));
             }
         }
     }

--- a/src/lib/Commands.ts
+++ b/src/lib/Commands.ts
@@ -136,65 +136,68 @@ export default class Commands {
 
         //check if its on correct channel
         if (!channels.includes(message.channel.id) && channels.length != 0) {
-            return message
-                .reply(`Any commands should be run on ${channels.map(channel => `<#${channel}>`).join(', ')}`)
-                .then(message => message.react('❌'));
+            message.react('❌');
+            return message.reply(
+                `Any commands should be run on ${channels.map(channel => `<#${channel}>`).join(', ')}`
+            );
         }
 
         if (command === 'prefix' && isOwner) {
             //check for missing arguments cause people dumb
             if (args.length < 1) {
-                return message.reply(`Correct Usage: ${prefix}prefix newPrefix.`).then(message => message.react('✋'));
+                message.react('✋');
+                return message.reply(`Correct Usage: ${prefix}prefix newPrefix.`);
             }
 
             const newPrefix = args.shift();
             options.handleBaseOptionOrAlias('prefix', newPrefix);
-            return message.reply(`Changed prefix from ${prefix} to ${newPrefix}`).then(message => message.react('✅'));
+            message.react('✅');
+            return message.reply(`Changed prefix from ${prefix} to ${newPrefix}`);
         } else if (command === 'setRole' && isOwner) {
             if (args.length < 1) {
-                return message.reply(`Correct Usage: ${prefix}setRole roleID.`).then(message => message.react('✋'));
+                message.react('✋');
+                return message.reply(`Correct Usage: ${prefix}setRole roleID.`);
             }
 
             const newRole = args.shift();
             options.handleBaseOptionOrAlias('roleID', newRole);
-            return message.reply(`Changed roleID to ${newRole}`).then(message => message.react('✅'));
+            message.react('✅');
+            return message.reply(`Changed roleID to ${newRole}`);
         } else if (command === 'add') {
             if (args.length < 2 && !message.attachments.first()) {
-                return message
-                    .reply(`Correct Usage: ${prefix}add command response.`)
-                    .then(message => message.react('✋'));
+                message.react('✋');
+                return message.reply(`Correct Usage: ${prefix}add command response.`);
             }
 
             try {
                 const [devCommand, devResponse] = commandParser(message.content);
                 if (['prefix', 'roleID'].includes(devCommand)) {
-                    return message
-                        .reply(`Can not add base value ${devCommand} as a command.`)
-                        .then(message => message.react('❌'));
+                    message.react('❌');
+                    return message.reply(`Can not add base value ${devCommand} as a command.`);
                 }
 
                 if (options.getOption(devCommand)[1] != undefined) {
-                    return message
-                        .reply(`Auto-reply for ${'`' + devCommand + '`'} already exists.`)
-                        .then(message => message.react('❌'));
+                    message.react('❌');
+                    return message.reply(`Auto-reply for ${'`' + devCommand + '`'} already exists.`);
                 }
 
                 options.handleOption(devCommand, devResponse, message.attachments.array());
-                return message.channel
-                    .send(
-                        `Added auto-reply: ${'`' + devCommand + '`'}, ${
-                            devResponse ? 'with the response: \n> ' + devResponse : 'with the attachment: \n>'
-                        }.`,
-                        { files: message.attachments.array() }
-                    )
-                    .then(message => message.react('✅'));
+                message.react('✅');
+                return message.channel.send(
+                    `Added auto-reply: ${'`' + devCommand + '`'}, ${
+                        devResponse ? 'with the response: \n> ' + devResponse : 'with the attachment: \n>'
+                    }.`,
+                    { files: message.attachments.array() }
+                );
             } catch (err) {
-                return message.reply(err).then(message => message.react('❌'));
+                message.react('❌');
+                return message.reply(err);
             }
         } else if (command === 'remove') {
             //check for missing arguments cause people dumb
             if (args.length < 1) {
-                return message.reply(`Correct Usage: ${prefix}remove command.`).then(message => message.react('✋'));
+                message.react('✋');
+                return message.reply(`Correct Usage: ${prefix}remove command.`);
             }
 
             const delCommand = args.filter(i => i).join(' ');
@@ -204,121 +207,110 @@ export default class Commands {
 
             const isAlias = typeof options.getOption(delCommand, true)[1] === 'string' ? 'alias' : '';
             options.deleteCommand(delCommand);
-            return message
-                .reply(`Deleted auto-reply for ${isAlias} ${'`' + delCommand + '`'}`)
-                .then(message => message.react('🚮'));
+            message.react('🚮');
+            return message.reply(`Deleted auto-reply for ${isAlias} ${'`' + delCommand + '`'}`);
         } else if (command === 'edit') {
             //check for missing arguments cause people dumb
             if (args.length < 2 && !message.attachments.first()) {
-                return message
-                    .reply(`Correct Usage: ${prefix}edit command newResponse.`)
-                    .then(message => message.react('✋'));
+                message.react('✋');
+                return message.reply(`Correct Usage: ${prefix}edit command newResponse.`);
             }
 
             try {
                 const [devCommand, devResponse] = commandParser(message.content);
                 if (['prefix', 'roleID'].includes(devCommand)) {
-                    return message
-                        .reply(`Can not add base value ${devCommand} as a command.`)
-                        .then(message => message.react('❌'));
+                    message.react('❌');
+                    return message.reply(`Can not add base value ${devCommand} as a command.`);
                 }
 
                 if (options.getOption(devCommand)[1] != undefined) {
                     options.handleOption(devCommand, devResponse, message.attachments.array());
-                    return message.channel
-                        .send(
-                            `Edited auto-reply: ${'`' + devCommand + '`'}, ${
-                                devResponse ? 'with the response: \n> ' + devResponse : 'with the attachment: \n>'
-                            }.`,
-                            { files: message.attachments.array() }
-                        )
-                        .then(message => message.react('✅'));
+                    message.react('✅');
+                    return message.channel.send(
+                        `Edited auto-reply: ${'`' + devCommand + '`'}, ${
+                            devResponse ? 'with the response: \n> ' + devResponse : 'with the attachment: \n>'
+                        }.`,
+                        { files: message.attachments.array() }
+                    );
                 }
 
-                return message
-                    .reply(`Auto-reply for ${'`' + devCommand + '`'} doesn't exist.`)
-                    .then(message => message.react('❌'));
+                message.react('❌');
+                return message.reply(`Auto-reply for ${'`' + devCommand + '`'} doesn't exist.`);
             } catch (err) {
-                return message.reply(err).then(message => message.react('❌'));
+                message.react('❌');
+                return message.reply(err);
             }
         } else if (command === 'list') {
-            return message.reply(options.getList()).then(message => message.react('✅'));
+            message.react('✅');
+            return message.reply(options.getList());
         } else if (command === 'alias') {
             if (args.length < 2) {
-                return message
-                    .reply(`Correct Usage: ${prefix}alias !help help.\nor: "not found" file not found`)
-                    .then(message => message.react('✋'));
+                message.react('✋');
+                return message.reply(`Correct Usage: ${prefix}alias !help help.\nor: "not found" file not found`);
             }
             try {
                 const [devAlias, devExistingCMD] = commandParser(message.content);
                 if (['prefix', 'roleID'].includes(devAlias)) {
-                    return message
-                        .reply(`Can not alias base value ${devAlias} as a command.`)
-                        .then(message => message.react('❌'));
+                    message.react('❌');
+                    return message.reply(`Can not alias base value ${devAlias} as a command.`);
                 }
 
                 if (['prefix', 'roleID'].includes(devExistingCMD)) {
-                    return message
-                        .reply(`Can not alias base value ${devExistingCMD} as a target.`)
-                        .then(message => message.react('❌'));
+                    message.react('❌');
+                    return message.reply(`Can not alias base value ${devExistingCMD} as a target.`);
                 }
 
                 if (options.getOption(devExistingCMD)[1] === undefined) {
-                    return message
-                        .reply(`Can not target alias for ${'`' + devExistingCMD + '`'} it doesn't exist.`)
-                        .then(message => message.react('❌'));
+                    message.react('❌');
+                    return message.reply(`Can not target alias for ${'`' + devExistingCMD + '`'} it doesn't exist.`);
                 }
 
                 if (options.getOption(devAlias)[1] !== undefined) {
-                    return message
-                        .reply(`Can not alias ${devAlias} as it already exists remove it first.`)
-                        .then(message => message.react('❌'));
+                    message.react('❌');
+                    return message.reply(`Can not alias ${devAlias} as it already exists remove it first.`);
                 }
 
                 options.handleBaseOptionOrAlias(devAlias, options.getOption(devExistingCMD)[0]);
-                return message.channel
-                    .send(`Added alias ${devAlias} => ${options.getOption(devExistingCMD)[0]}`)
-                    .then(message => message.react('✅'));
+                message.react('✅');
+                return message.channel.send(`Added alias ${devAlias} => ${options.getOption(devExistingCMD)[0]}`);
             } catch (err) {
-                return message.reply(err).then(message => message.react('❌'));
+                message.react('❌');
+                return message.reply(err);
             }
         } else if (command === 'rename') {
             if (args.length < 2) {
-                return message
-                    .reply(`Correct Usage: ${prefix}rename !help help.\nor: ${prefix}rename "not found" file not found`)
-                    .then(message => message.react('✋'));
+                message.react('✋');
+                return message.reply(
+                    `Correct Usage: ${prefix}rename !help help.\nor: ${prefix}rename "not found" file not found`
+                );
             }
 
             try {
                 const [devCurrent, devRename] = commandParser(message.content);
                 if (['prefix', 'roleID'].includes(devCurrent)) {
-                    return message
-                        .reply(`Can not rename base value ${'`' + devCurrent + '`'}.`)
-                        .then(message => message.react('❌'));
+                    message.react('❌');
+                    return message.reply(`Can not rename base value ${'`' + devCurrent + '`'}.`);
                 }
                 if (['prefix', 'roleID'].includes(devRename)) {
-                    return message
-                        .reply(`Can not rename to base value ${'`' + devRename + '`'}.`)
-                        .then(message => message.react('❌'));
+                    message.react('❌');
+                    return message.reply(`Can not rename to base value ${'`' + devRename + '`'}.`);
                 }
                 if (options.getOption(devCurrent)[1] === undefined) {
-                    return message
-                        .reply(`Can not rename ${'`' + devCurrent + '`'} it doesn't exist.`)
-                        .then(message => message.react('❌'));
+                    message.react('❌');
+                    return message.reply(`Can not rename ${'`' + devCurrent + '`'} it doesn't exist.`);
                 }
                 if (options.getOption(devRename)[1] !== undefined) {
-                    return message
-                        .reply(`Can not rename to ${'`' + devRename + '`'} as it already exists.`)
-                        .then(message => message.react('❌'));
+                    message.react('❌');
+                    return message.reply(`Can not rename to ${'`' + devRename + '`'} as it already exists.`);
                 }
 
                 options.renameCommand(devCurrent, devRename);
 
-                return message.channel
-                    .send(`Renamed ${'`' + devCurrent + '`'} => ${'`' + devRename + '`'}`)
-                    .then(message => message.react('✅'));
+                message.react('✅');
+                return message.channel.send(`Renamed ${'`' + devCurrent + '`'} => ${'`' + devRename + '`'}`);
             } catch (err) {
-                return message.reply(err).then(message => message.react('❌'));
+                message.react('❌');
+                return message.reply(err);
             }
         }
     }

--- a/src/lib/Option.ts
+++ b/src/lib/Option.ts
@@ -51,7 +51,8 @@ export default class Options {
         Object.keys(autoresponses).forEach(key => {
             const param = typeof autoresponses[key] === 'string' ? autoresponses[key] : key;
             cmds[param] ??= [];
-            cmds[param].push(key);
+            // if its the main command inserts it to the beginning else pushes it :)
+            cmds[param][key === param ? "unshift" : "push"](key)
         });
         return `Here's a list of available auto-response keywords:\n- ${Object.keys(cmds)
             .sort()

--- a/src/lib/Option.ts
+++ b/src/lib/Option.ts
@@ -34,10 +34,11 @@ export default class Options {
         this.currentOptions[option] = { content, files };
         writeFileSync(this.optionsPath, JSON.stringify(this.currentOptions, null, "\t"), { encoding: 'utf8' });
     }
-    public getOption(option: string): MessageOptions {
+    public getOption(option: string, canReturnAlias?: boolean) {
         // turn aliases to main so they'll still receive I have just sent a reply for that
-        if (typeof this.currentOptions[option] === "string") option = this.currentOptions[option];
-        return this.currentOptions[option] as MessageOptions;
+        option = Object.keys(this.currentOptions).find(i => i.toLowerCase() === option) || option;
+        if (!canReturnAlias && typeof this.currentOptions[option] === "string") option = this.currentOptions[option];
+        return [option, this.currentOptions[option]] as [string, MessageOptions];
     }
 
     public getList() {
@@ -45,14 +46,14 @@ export default class Options {
         delete autoresponses.prefix;
         delete autoresponses.roleID;
         const cmds: {
-            [key: string]: string
+            [key: string]: string[]
         } = {}
         Object.keys(autoresponses).forEach(key => {
             const param = typeof autoresponses[key] === "string" ? autoresponses[key] : key;
-            cmds[param] ??= "";
-            cmds[param] += `${key} `
+            cmds[param] ??= [];
+            cmds[param].push(key)
         })
-        return `Here's a list of available auto-response keywords:\n- ${Object.keys(cmds).sort().map(key => key.trim().replace(/  +/g, " | ")).join('\n- ')}`
+        return `Here's a list of available auto-response keywords:\n- ${Object.keys(cmds).sort().map(key => cmds[key].join(' | '))}`
     }
     public deleteCommand(command: string) {
         //delete aliases as well since otherwise they'd be pointing to nowhere.

--- a/src/lib/Option.ts
+++ b/src/lib/Option.ts
@@ -2,13 +2,27 @@ import { MessageAttachment, MessageOptions } from 'discord.js';
 import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync } from 'fs';
 import path from 'path';
 
+interface DefaultOptions {
+    prefix: string;
+    roleID: string;
+}
+
+interface OptionsContent extends DefaultOptions {
+    [keyword: string]:
+        | {
+              content?: string;
+              files?: MessageAttachment[];
+          }
+        | string;
+}
+ 
 export const defaultOptions = {
     prefix: '.',
     roleID: ''
 };
 
 export default class Options {
-    public currentOptions;
+    public currentOptions: OptionsContent;
 
     private readonly folderPath = path.join(__dirname, 'files');
 
@@ -29,16 +43,16 @@ export default class Options {
     // Only for prefix and roleID
     public handleBaseOptionOrAlias(option: string, newParam: string) {
         this.currentOptions[option] = newParam;
-        this.saveOptionsFile()
+        this.saveOptionsFile();
     }
     public handleOption(option: string, content: string, files?: MessageAttachment[]): void {
         this.currentOptions[option] = { content, files };
-        this.saveOptionsFile()
+        this.saveOptionsFile();
     }
     public getOption(option: string, canReturnAlias?: boolean) {
         // turn aliases to main so they'll still receive I have just sent a reply for that
         option = Object.keys(this.currentOptions).find(i => i.toLowerCase() === option.toLowerCase()) || option;
-        if (!canReturnAlias && typeof this.currentOptions[option] === 'string') option = this.currentOptions[option];
+        if (!canReturnAlias && typeof this.currentOptions[option] === 'string') option = this.currentOptions[option] as string;
         return [option, this.currentOptions[option]] as [string, MessageOptions];
     }
 
@@ -50,10 +64,10 @@ export default class Options {
             [key: string]: string[];
         } = {};
         Object.keys(autoresponses).forEach(key => {
-            const param = typeof autoresponses[key] === 'string' ? autoresponses[key] : key;
+            const param = (typeof autoresponses[key] === 'string' ? autoresponses[key] : key) as string;
             cmds[param] ??= [];
             // if its the main command inserts it to the beginning else pushes it :)
-            cmds[param][key === param ? "unshift" : "push"](key)
+            cmds[param][key === param ? 'unshift' : 'push'](key);
         });
         return `Here's a list of available auto-response keywords:\n- ${Object.keys(cmds)
             .sort()
@@ -67,7 +81,7 @@ export default class Options {
             this.rePointAliases(command);
         }
         delete this.currentOptions[command];
-        this.saveOptionsFile()
+        this.saveOptionsFile();
     }
 
     public renameCommand(command: string, newCommand: string) {

--- a/src/lib/Option.ts
+++ b/src/lib/Option.ts
@@ -1,3 +1,4 @@
+import { MessageAttachment, MessageOptions } from 'discord.js';
 import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync } from 'graceful-fs';
 
 export const defaultOptions = {
@@ -25,13 +26,16 @@ export default class Options {
         }
     }
 
-    public handleOption(option: string, value: string): void {
-        this.currentOptions[option] = value;
-        writeFileSync(this.optionsPath, JSON.stringify(this.currentOptions, null, 4), { encoding: 'utf8' });
+    public handleOption(option: string, content: string, files?: MessageAttachment[]): void {
+        this.currentOptions[option] = { content, files };
+        writeFileSync(this.optionsPath, JSON.stringify(this.currentOptions, null, "\t"), { encoding: 'utf8' });
+    }
+    public getOption(option: string): MessageOptions {
+        return this.currentOptions[option] as MessageOptions;
     }
 
     public deleteCommand(command: string) {
         delete this.currentOptions[command];
-        writeFileSync(this.optionsPath, JSON.stringify(this.currentOptions, null, 4), { encoding: 'utf8' });
+        writeFileSync(this.optionsPath, JSON.stringify(this.currentOptions, null, "\t"), { encoding: 'utf8' });
     }
 }

--- a/src/lib/Option.ts
+++ b/src/lib/Option.ts
@@ -53,7 +53,7 @@ export default class Options {
             cmds[param] ??= [];
             cmds[param].push(key)
         })
-        return `Here's a list of available auto-response keywords:\n- ${Object.keys(cmds).sort().map(key => cmds[key].join(' | '))}`
+        return `Here's a list of available auto-response keywords:\n- ${Object.keys(cmds).sort().map(key => cmds[key].join(' | ')).join('\n- ')}`
     }
     public deleteCommand(command: string) {
         //delete aliases as well since otherwise they'd be pointing to nowhere.

--- a/src/lib/Option.ts
+++ b/src/lib/Option.ts
@@ -71,6 +71,7 @@ export default class Options {
     public renameCommand(command: string, newCommand: string) {
         this.rePointAliases(command, newCommand);
         delete Object.assign(this.currentOptions, { [newCommand]: this.currentOptions[command] })[command];
+        this.saveOptionsFile();
     }
 
     public rePointAliases(command: string, newCommandOrDelete?: string | undefined) {
@@ -83,7 +84,6 @@ export default class Options {
                 }
             }
         });
-        if (!newCommandOrDelete) this.saveOptionsFile()
     }
 
     private saveOptionsFile() {

--- a/src/lib/Option.ts
+++ b/src/lib/Option.ts
@@ -27,17 +27,17 @@ export default class Options {
     }
     // Only for prefix and roleID
     public handleBaseOptionOrAlias(option: string, newParam: string) {
-        this.currentOptions[option] = newParam
-        writeFileSync(this.optionsPath, JSON.stringify(this.currentOptions, null, "\t"), { encoding: 'utf8' });
+        this.currentOptions[option] = newParam;
+        writeFileSync(this.optionsPath, JSON.stringify(this.currentOptions, null, '\t'), { encoding: 'utf8' });
     }
     public handleOption(option: string, content: string, files?: MessageAttachment[]): void {
         this.currentOptions[option] = { content, files };
-        writeFileSync(this.optionsPath, JSON.stringify(this.currentOptions, null, "\t"), { encoding: 'utf8' });
+        writeFileSync(this.optionsPath, JSON.stringify(this.currentOptions, null, '\t'), { encoding: 'utf8' });
     }
     public getOption(option: string, canReturnAlias?: boolean) {
         // turn aliases to main so they'll still receive I have just sent a reply for that
         option = Object.keys(this.currentOptions).find(i => i.toLowerCase() === option) || option;
-        if (!canReturnAlias && typeof this.currentOptions[option] === "string") option = this.currentOptions[option];
+        if (!canReturnAlias && typeof this.currentOptions[option] === 'string') option = this.currentOptions[option];
         return [option, this.currentOptions[option]] as [string, MessageOptions];
     }
 
@@ -46,34 +46,37 @@ export default class Options {
         delete autoresponses.prefix;
         delete autoresponses.roleID;
         const cmds: {
-            [key: string]: string[]
-        } = {}
+            [key: string]: string[];
+        } = {};
         Object.keys(autoresponses).forEach(key => {
-            const param = typeof autoresponses[key] === "string" ? autoresponses[key] : key;
+            const param = typeof autoresponses[key] === 'string' ? autoresponses[key] : key;
             cmds[param] ??= [];
-            cmds[param].push(key)
-        })
-        return `Here's a list of available auto-response keywords:\n- ${Object.keys(cmds).sort().map(key => cmds[key].join(' | ')).join('\n- ')}`
+            cmds[param].push(key);
+        });
+        return `Here's a list of available auto-response keywords:\n- ${Object.keys(cmds)
+            .sort()
+            .map(key => cmds[key].join(' | '))
+            .join('\n- ')}`;
     }
     public deleteCommand(command: string) {
         //delete aliases as well since otherwise they'd be pointing to nowhere.
-        if (typeof this.currentOptions[command] !== "string") {
+        if (typeof this.currentOptions[command] !== 'string') {
             // Delete aliases for the command
-            this.rePointAliases(command)
+            this.rePointAliases(command);
         }
         delete this.currentOptions[command];
-        writeFileSync(this.optionsPath, JSON.stringify(this.currentOptions, null, "\t"), { encoding: 'utf8' });
+        writeFileSync(this.optionsPath, JSON.stringify(this.currentOptions, null, '\t'), { encoding: 'utf8' });
     }
 
     public rePointAliases(command: string, newCommandOrDelete?: string | undefined) {
         Object.keys(this.currentOptions).forEach(key => {
             if (this.currentOptions[key] === command) {
                 if (newCommandOrDelete === undefined) {
-                    delete this.currentOptions[key]
+                    delete this.currentOptions[key];
                 } else {
-                    this.currentOptions[key] = newCommandOrDelete
+                    this.currentOptions[key] = newCommandOrDelete;
                 }
             }
-        })
+        });
     }
 }

--- a/src/lib/Option.ts
+++ b/src/lib/Option.ts
@@ -28,11 +28,11 @@ export default class Options {
     // Only for prefix and roleID
     public handleBaseOptionOrAlias(option: string, newParam: string) {
         this.currentOptions[option] = newParam;
-        writeFileSync(this.optionsPath, JSON.stringify(this.currentOptions, null, '\t'), { encoding: 'utf8' });
+        this.saveOptionsFile()
     }
     public handleOption(option: string, content: string, files?: MessageAttachment[]): void {
         this.currentOptions[option] = { content, files };
-        writeFileSync(this.optionsPath, JSON.stringify(this.currentOptions, null, '\t'), { encoding: 'utf8' });
+        this.saveOptionsFile()
     }
     public getOption(option: string, canReturnAlias?: boolean) {
         // turn aliases to main so they'll still receive I have just sent a reply for that
@@ -65,7 +65,12 @@ export default class Options {
             this.rePointAliases(command);
         }
         delete this.currentOptions[command];
-        writeFileSync(this.optionsPath, JSON.stringify(this.currentOptions, null, '\t'), { encoding: 'utf8' });
+        this.saveOptionsFile()
+    }
+
+    public renameCommand(command: string, newCommand: string) {
+        this.rePointAliases(command, newCommand);
+        delete Object.assign(this.currentOptions, { [newCommand]: this.currentOptions[command] })[command];
     }
 
     public rePointAliases(command: string, newCommandOrDelete?: string | undefined) {
@@ -78,5 +83,10 @@ export default class Options {
                 }
             }
         });
+        if (!newCommandOrDelete) this.saveOptionsFile()
+    }
+
+    private saveOptionsFile() {
+        writeFileSync(this.optionsPath, JSON.stringify(this.currentOptions, null, '\t'), { encoding: 'utf8' });
     }
 }

--- a/src/lib/Option.ts
+++ b/src/lib/Option.ts
@@ -36,7 +36,7 @@ export default class Options {
     }
     public getOption(option: string, canReturnAlias?: boolean) {
         // turn aliases to main so they'll still receive I have just sent a reply for that
-        option = Object.keys(this.currentOptions).find(i => i.toLowerCase() === option) || option;
+        option = Object.keys(this.currentOptions).find(i => i.toLowerCase() === option.toLowerCase()) || option;
         if (!canReturnAlias && typeof this.currentOptions[option] === 'string') option = this.currentOptions[option];
         return [option, this.currentOptions[option]] as [string, MessageOptions];
     }

--- a/src/lib/Option.ts
+++ b/src/lib/Option.ts
@@ -1,5 +1,6 @@
 import { MessageAttachment, MessageOptions } from 'discord.js';
-import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync } from 'graceful-fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync } from 'fs';
+import path from 'path';
 
 export const defaultOptions = {
     prefix: '.',
@@ -9,9 +10,9 @@ export const defaultOptions = {
 export default class Options {
     public currentOptions;
 
-    private readonly folderPath: string = './files';
+    private readonly folderPath = path.join(__dirname, 'files');
 
-    private readonly optionsPath: string = './files/options.json';
+    private readonly optionsPath = path.join(__dirname, 'files', 'options.json');
 
     public init(): void {
         if (!existsSync(this.folderPath)) {
@@ -22,7 +23,7 @@ export default class Options {
             writeFileSync(this.optionsPath, JSON.stringify(defaultOptions, null, 4), { encoding: 'utf8' });
             this.currentOptions = defaultOptions;
         } else {
-            this.currentOptions = JSON.parse(readFileSync(this.optionsPath));
+            this.currentOptions = JSON.parse(readFileSync(this.optionsPath, { encoding: 'utf8' }));
         }
     }
     // Only for prefix and roleID

--- a/src/lib/Option.ts
+++ b/src/lib/Option.ts
@@ -15,7 +15,7 @@ interface OptionsContent extends DefaultOptions {
           }
         | string;
 }
- 
+
 export const defaultOptions = {
     prefix: '.',
     roleID: ''
@@ -24,9 +24,9 @@ export const defaultOptions = {
 export default class Options {
     public currentOptions: OptionsContent;
 
-    private readonly folderPath = path.join(__dirname, 'files');
+    private readonly folderPath = path.join(__dirname, '..', '..', 'files');
 
-    private readonly optionsPath = path.join(__dirname, 'files', 'options.json');
+    private readonly optionsPath = path.join(__dirname, '..', '..', 'files', 'options.json');
 
     public init(): void {
         if (!existsSync(this.folderPath)) {
@@ -52,7 +52,8 @@ export default class Options {
     public getOption(option: string, canReturnAlias?: boolean) {
         // turn aliases to main so they'll still receive I have just sent a reply for that
         option = Object.keys(this.currentOptions).find(i => i.toLowerCase() === option.toLowerCase()) || option;
-        if (!canReturnAlias && typeof this.currentOptions[option] === 'string') option = this.currentOptions[option] as string;
+        if (!canReturnAlias && typeof this.currentOptions[option] === 'string')
+            option = this.currentOptions[option] as string;
         return [option, this.currentOptions[option]] as [string, MessageOptions];
     }
 

--- a/src/lib/Option.ts
+++ b/src/lib/Option.ts
@@ -25,7 +25,11 @@ export default class Options {
             this.currentOptions = JSON.parse(readFileSync(this.optionsPath));
         }
     }
-
+    // Only for prefix and roleID
+    public handleBaseOption(option: "prefix" | "roleID", newParam: string) {
+        this.currentOptions[option] = newParam
+        writeFileSync(this.optionsPath, JSON.stringify(this.currentOptions, null, "\t"), { encoding: 'utf8' });
+    }
     public handleOption(option: string, content: string, files?: MessageAttachment[]): void {
         this.currentOptions[option] = { content, files };
         writeFileSync(this.optionsPath, JSON.stringify(this.currentOptions, null, "\t"), { encoding: 'utf8' });


### PR DESCRIPTION
Since this pr has breaking changes I suggest merging it for v2.
### Changes
- Change options.json structure (Breaking!!)
- Match words that don't match the casing. (ie. command is `test` it'll match `Test`)
### Features
- Support for attachments.
- Support for multiple words including the ability to escape quotes.
- Spam protection. - @idinium96
- Support for aliases.
- Support for renaming commands.
### Fixes
- Being able to change `prefix` and `roleID` with `edit` command or even removing them with `remove`.