### PR TITLE
Use tesseract v5 instead of v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 Wiki bot for TF2Autobot Discord server.
 
-Required dependency: `tesseract` which can be obtained by `sudo apt install tesseract-ocr` (Linux)
+Required dependency: `tesseract v5 alpha` which can be obtained by
+
+```
+sudo add-apt-repository ppa:alex-p/tesseract-ocr-devel
+sudo apt-get update
+sudo apt-get install tesseract-ocr tesseract-ocr-eng
+```
+
+(Linux)

--- a/src/lib/Commands.ts
+++ b/src/lib/Commands.ts
@@ -403,6 +403,10 @@ export default class Commands {
                 return message.reply(err);
             }
         } else if (command === 'addocr') {
+            if (args.length < 2) {
+                message.react('✋');
+                return message.reply(`**Correct Usage**: \`${prefix}addOcr <existingKeyword> <textToSearchFor>\``);
+            }
             const [targetCommand, targetCommandObject, text] = commandParser(message.content);
             if (['prefix', 'roleID'].includes(targetCommand)) {
                 message.react('❌');
@@ -417,6 +421,10 @@ export default class Commands {
             message.react('✅');
             return message.channel.send(`Created an ocr for \`${targetCommand}\`\n With the text:\n\`${text}\``);
         } else if (command === 'removeocr') {
+            if (args.length < 1) {
+                message.react('✋');
+                return message.reply(`**Correct Usage**: \`${prefix}removeOcr <textToSearchFor>\``);
+            }
             const delCommand = args.filter(i => i).join(' ');
             if (!options.currentOcr[delCommand]) {
                 message.react('❌');


### PR DESCRIPTION
In my testing I've found out that v5 has a higher accuracy than v4 so I've updated README for instructions to use v5.

Also fixes the crashing issue when there are params missing on the new ocr commands.